### PR TITLE
Fixed regex escapes and more

### DIFF
--- a/pySBD/lang/common/numbers.py
+++ b/pySBD/lang/common/numbers.py
@@ -7,7 +7,7 @@ class Common(object):
     SENTENCE_BOUNDARY_REGEX = r"\\u{ff08}(?:[^\\u{ff09}])*\\u{ff09}(?=\s?[A-Z])|\\u{300c}(?:[^\\u{300d}])*\\u{300d}(?=\s[A-Z])|\((?:[^\)]){2,}\)(?=\s[A-Z])|\'(?:[^\'])*[^,]\'(?=\s[A-Z])|\"(?:[^\"])*[^,]\"(?=\s[A-Z])|\“(?:[^\”])*[^,]\”(?=\s[A-Z])|\S.*?[。．.！!?？ȸȹ☉☈☇☄]"
 
     # # Rubular: http://rubular.com/r/NqCqv372Ix
-    # QUOTATION_AT_END_OF_SENTENCE_REGEX = r'[!?\.-][\"\'\u{201d}\u{201c}]\s{1}[A-Z]'
+    QUOTATION_AT_END_OF_SENTENCE_REGEX = r'[!?\.][\"\'“”]\s{1}[A-Z]'
 
     # # Rubular: http://rubular.com/r/6flGnUMEVl
     PARENS_BETWEEN_DOUBLE_QUOTES_REGEX = r'["\”]\s\(.*\)\s["\“]'
@@ -16,7 +16,7 @@ class Common(object):
     # BETWEEN_DOUBLE_QUOTES_REGEX = / "(?:[^"])*[^, ]"|“(?: [ ^”])*[^, ]”/
 
     # # Rubular: http://rubular.com/r/JMjlZHAT4g
-    # SPLIT_SPACE_QUOTATION_AT_END_OF_SENTENCE_REGEX= / (?<= [!?\.-][\"\'\u{201d}\u{201c}])\s{1}(?=[A-Z]) /
+    SPLIT_SPACE_QUOTATION_AT_END_OF_SENTENCE_REGEX = r'(?<=[!?\.][\"\'“”])\s{1}(?=[A-Z])'
 
     # # Rubular: http://rubular.com/r/mQ8Es9bxtk
     # CONTINUOUS_PUNCTUATION_REGEX= / (?<=\S)(!|\?){3, }(?=(\s |\z |$)) /
@@ -113,6 +113,8 @@ class Common(object):
     #     SingleUpperCaseLetterAtStartOfLineRule,
     #     SingleUpperCaseLetterRule
     #     ]
+
+
 if __name__ == "__main__":
     txt = 'My friend work at Yahoo☄ amazing right?'
     print(re.findall(Common.SENTENCE_BOUNDARY_REGEX, txt))

--- a/pySBD/processor.py
+++ b/pySBD/processor.py
@@ -43,22 +43,16 @@ class Processor(object):
         sents = list(filter(None, sents))
         # https://stackoverflow.com/questions/4698493/can-i-add-custom-methods-attributes-to-built-in-python-types
         sents = [
-            Text(e).apply(Standard.SingleNewLineRule, *EllipsisRules.All)
-            for e in sents
+            Text(s).apply(Standard.SingleNewLineRule, *EllipsisRules.All)
+            for s in sents
         ]
-        # print(sents)
-        # new_sents = []
-        # for s in sents:
-        #     print(s)
-        #     s = self.check_for_punctuation(s)
-        #     if not s:
-        #         continue
-        #     elif len(s) == 1:
-        #         s = Text(s).apply(*SubSymbolsRules.All)
-        #         new_sents.append(s)
-        #     else:
-        #         s = Text(s).apply(*SubSymbolsRules.All)
-        #         new_sents.append(s)
+        new_sents = [self.check_for_punctuation(s) for s in sents]
+        # flatten list of list of sentences
+        sents = [s for sents in new_sents for s in sents]
+        sents = [
+            Text(s).apply(*SubSymbolsRules.All)
+            for s in sents
+        ]
 
         # SubSymbolsRules
         # post_process_segments
@@ -102,7 +96,10 @@ class Processor(object):
         # if any(re.search(re.escape(r'{}'.format(p)), txt)
         #        for p in Standard.Punctuations):
         if any(p in txt for p in Standard.Punctuations):
-            self.process_text(txt)
+            sents = self.process_text(txt)
+            return sents
+        else:
+            return txt
 
     def process_text(self, txt):
         # if not any(p in txt[-1] for p in Standard.Punctuations):


### PR DESCRIPTION
In punctuation_replacer -> 
```
LeftParen = Rule(re.escape(r'('), '(')
```
changed to

```
Rule('\(', '\\(')
```
-------------
## Added more functions:

Add `post_process_segments` and `SubSingleQuoteRule` functions
Add `check_for_punctuation` and `SubSymbolsRules` functions
Stable `punctuation_replacer` and `between_punctuation`

