### PR TITLE
fixed typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ print(seg.segment(text))
 
 ```python
 import spacy
-from pysbd.util import PySBDFactory
+from pysbd.utils import PySBDFactory
 
 nlp = spacy.blank('en')
 


### PR DESCRIPTION
Hi, Nipun.
I found a tiny typo in your README example snippet.
Idk the past code structure, but I guess you changed the name of the file from `util.py` to `utils.py`.
So, I fixed this wrong reference in import line.
Thank you for porting this amazing library 👍 