### PR TITLE
Extend normal text rules

### DIFF
--- a/pysbd/clean/rules.py
+++ b/pysbd/clean/rules.py
@@ -61,7 +61,10 @@ class CleanRules(object):
     QuotationsFirstRule = Rule(r"''", '"')
     QuotationsSecondRule = Rule(r'``', '"')
 
-
+    # Rubular: http://rubular.com/r/eaNwGavmdo
+    NewLineInMiddleOfSentenceNoSpacesRule = Rule(r"\n(?=[a-z])", ' ')
+    
+    
 class HTML(object):
     # Rubular: http://rubular.com/r/9d0OVOEJWj
     HTMLTagRule = Rule(r"<\/?\w+((\s+\w+(\s*=\s*(?:\".*?\"|'.*?'|[\^'\">\s]+))?)+\s*|\s*)\/?>", '')


### PR DESCRIPTION
Add pdf rule [NewLineInMiddleOfSentenceNoSpacesRule](https://github.com/nipunsadvilkar/pySBD/blob/a2bb4510e65b1fd6c37e2162005076db0e984fb0/pysbd/clean/rules.py#L80) to normal text rules so it can handle cases like https://rubular.com/r/eaNwGavmdo in a normal text 