### PR TITLE
Apply pdf rules

### DIFF
--- a/pysbd/cleaner.py
+++ b/pysbd/cleaner.py
@@ -63,9 +63,9 @@ class Cleaner(object):
                                      cr.ReplaceNewlineWithCarriageReturnRule)
             else:
                 self.text = Text(
-                    self.text).apply(cr.NewLineFollowedByPeriodRule,
-                                     cr.ReplaceNewlineWithCarriageReturnRule,
-                                     PDF.NewLineInMiddleOfSentenceNoSpacesRule)
+                    self.text).apply(PDF.NewLineInMiddleOfSentenceNoSpacesRule,
+                                     cr.NewLineFollowedByPeriodRule,
+                                     cr.ReplaceNewlineWithCarriageReturnRule)
 
     def replace_escaped_newlines(self):
         self.text = Text(

--- a/pysbd/cleaner.py
+++ b/pysbd/cleaner.py
@@ -57,11 +57,15 @@ class Cleaner(object):
         if self.doc_type == 'pdf':
             self.remove_pdf_line_breaks()
         else:
-            self.text = Text(
-                self.text).apply(cr.NewLineFollowedByPeriodRule,
-                                 cr.ReplaceNewlineWithCarriageReturnRule)
-            if self.apply_pdf_rules:
-                self.text = Text(self.text).apply(PDF.NewLineInMiddleOfSentenceNoSpacesRule)
+            if not self.apply_pdf_rules:
+                self.text = Text(
+                    self.text).apply(cr.NewLineFollowedByPeriodRule,
+                                     cr.ReplaceNewlineWithCarriageReturnRule)
+            else:
+                self.text = Text(
+                    self.text).apply(cr.NewLineFollowedByPeriodRule,
+                                     cr.ReplaceNewlineWithCarriageReturnRule,
+                                     PDF.NewLineInMiddleOfSentenceNoSpacesRule)
 
     def replace_escaped_newlines(self):
         self.text = Text(

--- a/pysbd/cleaner.py
+++ b/pysbd/cleaner.py
@@ -7,10 +7,11 @@ from pysbd.lang.standard import Abbreviation
 
 class Cleaner(object):
 
-    def __init__(self, text, language='common', doc_type=None):
+    def __init__(self, text, language='common', doc_type=None, apply_pdf_rules=True):
         self.text = text
         self.language = language
         self.doc_type = doc_type
+        self.apply_pdf_rules = apply_pdf_rules
 
     def clean(self):
         if not self.text:
@@ -59,6 +60,8 @@ class Cleaner(object):
             self.text = Text(
                 self.text).apply(cr.NewLineFollowedByPeriodRule,
                                  cr.ReplaceNewlineWithCarriageReturnRule)
+            if self.apply_pdf_rules:
+                self.text = Text(self.text).apply(PDF.NewLineInMiddleOfSentenceNoSpacesRule)
 
     def replace_escaped_newlines(self):
         self.text = Text(

--- a/pysbd/cleaner.py
+++ b/pysbd/cleaner.py
@@ -7,7 +7,7 @@ from pysbd.lang.standard import Abbreviation
 
 class Cleaner(object):
 
-    def __init__(self, text, language='common', doc_type=None, apply_pdf_rules=True):
+    def __init__(self, text, language='common', doc_type=None, apply_pdf_rules=False):
         self.text = text
         self.language = language
         self.doc_type = doc_type

--- a/pysbd/cleaner.py
+++ b/pysbd/cleaner.py
@@ -54,18 +54,12 @@ class Cleaner(object):
                                  PDF.NewLineInMiddleOfSentenceNoSpacesRule)
 
     def replace_newlines(self):
-        if self.doc_type == 'pdf':
+        if self.doc_type == 'pdf' or self.apply_pdf_rules:
             self.remove_pdf_line_breaks()
         else:
-            if not self.apply_pdf_rules:
-                self.text = Text(
-                    self.text).apply(cr.NewLineFollowedByPeriodRule,
-                                     cr.ReplaceNewlineWithCarriageReturnRule)
-            else:
-                self.text = Text(
-                    self.text).apply(PDF.NewLineInMiddleOfSentenceNoSpacesRule,
-                                     cr.NewLineFollowedByPeriodRule,
-                                     cr.ReplaceNewlineWithCarriageReturnRule)
+            self.text = Text(
+                self.text).apply(cr.NewLineFollowedByPeriodRule,
+                                 cr.ReplaceNewlineWithCarriageReturnRule)
 
     def replace_escaped_newlines(self):
         self.text = Text(

--- a/pysbd/segmenter.py
+++ b/pysbd/segmenter.py
@@ -38,7 +38,7 @@ class Segmenter(object):
             raise ValueError("char_span must be False if clean is True. "
                              "Since `clean=True` will modify original text.")
         elif self.clean:
-            text = Cleaner(text, doc_type=self.doc_type, apply_pdf_rules=apply_pdf_rules).clean()
+            text = Cleaner(text, doc_type=self.doc_type, apply_pdf_rules=self.apply_pdf_rules).clean()
         processor = Processor(text, char_span=self.char_span)
         segments = processor.process()
         return segments

--- a/pysbd/segmenter.py
+++ b/pysbd/segmenter.py
@@ -6,7 +6,7 @@ from pysbd.cleaner import Cleaner
 
 class Segmenter(object):
 
-    def __init__(self, language="en", clean=False, doc_type=None, char_span=False, apply_pdf_rules=True):
+    def __init__(self, language="en", clean=False, doc_type=None, char_span=False, apply_pdf_rules=False):
         """Segments a text into an list of sentences
         with or withour character offsets from original text
 

--- a/pysbd/segmenter.py
+++ b/pysbd/segmenter.py
@@ -6,7 +6,7 @@ from pysbd.cleaner import Cleaner
 
 class Segmenter(object):
 
-    def __init__(self, language="en", clean=False, doc_type=None, char_span=False):
+    def __init__(self, language="en", clean=False, doc_type=None, char_span=False, apply_pdf_rules=True):
         """Segments a text into an list of sentences
         with or withour character offsets from original text
 
@@ -29,6 +29,7 @@ class Segmenter(object):
         self.clean = clean
         self.doc_type = doc_type
         self.char_span = char_span
+        self.apply_pdf_rules = apply_pdf_rules
 
     def segment(self, text):
         if not text:
@@ -37,7 +38,7 @@ class Segmenter(object):
             raise ValueError("char_span must be False if clean is True. "
                              "Since `clean=True` will modify original text.")
         elif self.clean:
-            text = Cleaner(text, doc_type=self.doc_type).clean()
+            text = Cleaner(text, doc_type=self.doc_type, apply_pdf_rules=apply_pdf_rules).clean()
         processor = Processor(text, char_span=self.char_span)
         segments = processor.process()
         return segments


### PR DESCRIPTION
This PR will allow users to apply pdf cleaning rules on normal text files.
For example, if we have a sentence `This is a sentence\ncut off in the middle because pdf.` in a normal text, we would get `This is a sentence` and `cut off in the middle because pdf.` 
This PR will return `This is a sentence cut off in the middle because pdf.` instead.