### PR TITLE
Fix spacy component example (issue #96)

### DIFF
--- a/examples/pysbd_as_spacy_component.py
+++ b/examples/pysbd_as_spacy_component.py
@@ -7,21 +7,22 @@ pip install spacy
 import pysbd
 import spacy
 
-def pysbd_sentence_boundaries(doc):
-    seg = pysbd.Segmenter(language="en", clean=False, char_span=True)
-    sents_char_spans = seg.segment(doc.text)
-    char_spans = [doc.char_span(sent_span.start, sent_span.end) for sent_span in sents_char_spans]
-    start_token_ids = [span[0].idx for span in char_spans if span is not None]
-    for token in doc:
-        token.is_sent_start = True if token.idx in start_token_ids else False
-    return doc
-
 if __name__ == "__main__":
     text = "My name is Jonas E. Smith.          Please turn to p. 55."
     nlp = spacy.blank('en')
+    
+    @nlp.component("sbd")
+    def pysbd_sentence_boundaries(doc):
+        seg = pysbd.Segmenter(language="en", clean=False, char_span=True)
+        sents_char_spans = seg.segment(doc.text)
+        char_spans = [doc.char_span(sent_span.start, sent_span.end, alignment_mode="contract") for sent_span in sents_char_spans]
+        start_token_ids = [span[0].idx for span in char_spans if span is not None]
+        for token in doc:
+            token.is_sent_start = True if token.idx in start_token_ids else False
+        return doc
 
     # add as a spacy pipeline component
-    nlp.add_pipe(pysbd_sentence_boundaries)
+    nlp.add_pipe("sbd", first=True)
 
     doc = nlp(text)
     print('sent_id', 'sentence', sep='\t|\t')


### PR DESCRIPTION
Update the example to work with the latest spacy as installed by `pip install spacy` (version 3.0.6), and fix failure to segment sentences due to `doc.char_span` returning None. Fixes #96.

**Add pipe to spacy model**
Use the current spacy recommended way to add the pipe to a model.

**Fix sentences not split due to extra chars**
The `doc.char_span` uses `alignment_mode="strict"` by default, which returns `None` when `sent_char_spans` contains trailing spaces, for example. Change the `alignment_mode` to `"contract"` so that it returns correct spans.