### PR TITLE
Update pysbd_as_spacy_component.py

### DIFF
--- a/examples/pysbd_as_spacy_component.py
+++ b/examples/pysbd_as_spacy_component.py
@@ -7,6 +7,10 @@ pip install spacy
 import pysbd
 import spacy
 
+from spacy.language import Language
+
+@Language.component("pysbd_sentence_boundaries")
+
 def pysbd_sentence_boundaries(doc):
     seg = pysbd.Segmenter(language="en", clean=False, char_span=True)
     sents_char_spans = seg.segment(doc.text)
@@ -21,7 +25,7 @@ if __name__ == "__main__":
     nlp = spacy.blank('en')
 
     # add as a spacy pipeline component
-    nlp.add_pipe(pysbd_sentence_boundaries)
+    nlp.add_pipe("pysbd_sentence_boundaries")
 
     doc = nlp(text)
     print('sent_id', 'sentence', sep='\t|\t')


### PR DESCRIPTION
Thanks for a great sentence splitting package. A small contribution, after troubleshooting, why the code was not working out of the box. The spacy v3 requires a string in the add_pipe() call. The component need to be declared using the language decorator. See also https://spacy.io/usage/processing-pipelines#custom-components. Hope it helps other users.