### PR TITLE
Added decorator as required by latest SpaCy

### DIFF
--- a/examples/pysbd_as_spacy_component.py
+++ b/examples/pysbd_as_spacy_component.py
@@ -7,6 +7,8 @@ pip install spacy
 import pysbd
 import spacy
 
+
+@spacy.Language.component("pysbd")
 def pysbd_sentence_boundaries(doc):
     seg = pysbd.Segmenter(language="en", clean=False, char_span=True)
     sents_char_spans = seg.segment(doc.text)
@@ -16,12 +18,13 @@ def pysbd_sentence_boundaries(doc):
         token.is_sent_start = True if token.idx in start_token_ids else False
     return doc
 
+
 if __name__ == "__main__":
     text = "My name is Jonas E. Smith.          Please turn to p. 55."
     nlp = spacy.blank('en')
 
     # add as a spacy pipeline component
-    nlp.add_pipe(pysbd_sentence_boundaries)
+    nlp.add_pipe("pysbd")
 
     doc = nlp(text)
     print('sent_id', 'sentence', sep='\t|\t')


### PR DESCRIPTION
Hello!

In using `pySBD`, I've noticed that the current example script no longer works with the latest version of SpaCy (`3.3.0`). This is the traceback I get: 

```
Traceback (most recent call last):
  File "/Users/lucas/Code/significant-statements-extraction/scripts/test_pysbd.py", line 27, in <module>
    nlp.add_pipe(pysbd_sentence_boundaries)
  File "/Users/lucas/miniforge3/envs/pytorch_p39/lib/python3.9/site-packages/spacy/language.py", line 773, in add_pipe
    raise ValueError(err)
ValueError: [E966] `nlp.add_pipe` now takes the string name of the registered component factory, not a callable component. Expected string, but got <function pysbd_sentence_boundaries at 0x11ffa9160> (name: 'None').

- If you created your component with `nlp.create_pipe('name')`: remove nlp.create_pipe and call `nlp.add_pipe('name')` instead.

- If you passed in a component like `TextCategorizer()`: call `nlp.add_pipe` with the string name instead, e.g. `nlp.add_pipe('textcat')`.

- If you're using a custom component: Add the decorator `@Language.component` (for function components) or `@Language.factory` (for class components / factories) to your custom component and assign it a name, e.g. `@Language.component('your_name')`. You can then run `nlp.add_pipe('your_name')` to add it to the pipeline.
```

This pull requests add a `@Language.component` decorator to make `pySBD` available in SpaCy again.
